### PR TITLE
Use `apt` install method from https://dart.dev/get-dart Linux

### DIFF
--- a/.github/workflows/test-feature.yml
+++ b/.github/workflows/test-feature.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         includes:
           - image: mcr.microsoft.com/devcontainers/base:ubuntu
+            options: '{ "version": "3.0.0" }'
           - image: debian:bookworm-slim
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-feature.yml
+++ b/.github/workflows/test-feature.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - image: mcr.microsoft.com/devcontainers/base:ubuntu
-            options: '{ "version": "3.0.0" }'
+            options: '{ "version": "2.9.0-4.0.dev-1" }'
           - image: debian:bookworm-slim
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-feature.yml
+++ b/.github/workflows/test-feature.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        includes:
+        include:
           - image: mcr.microsoft.com/devcontainers/base:ubuntu
             options: '{ "version": "3.0.0" }'
           - image: debian:bookworm-slim

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,10 @@
 set -ex
 source lib.sh
 
-check_packages wget gpg
+check_packages wget gpg apt-transport-https
+wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' >/etc/apt/sources.list.d/dart_stable.list
 
-sudo apt-get update
-sudo apt-get install apt-transport-https
-wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
-echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+apt-get install dart
+
+updaterc 'export PATH="$PATH:/usr/lib/dart/bin"'

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,13 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor 
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' >/etc/apt/sources.list.d/dart_stable.list
 
 apt-get update
-apt-get install dart
+if [[ $VERSION == latest ]]; then
+  apt-get install dart
+else
+  apt-get install dart=$VERSION
+fi
 
 updaterc 'export PATH="$PATH:/usr/lib/dart/bin"'
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ check_packages wget gpg apt-transport-https
 wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' >/etc/apt/sources.list.d/dart_stable.list
 
+apt-get update
 apt-get install dart
 
 updaterc 'export PATH="$PATH:/usr/lib/dart/bin"'

--- a/install.sh
+++ b/install.sh
@@ -1,39 +1,10 @@
-#!/bin/sh
-set -eux
+#!/bin/bash
+set -ex
+source lib.sh
 
-BASEURL="https://storage.googleapis.com/dart-archive/channels"
-DART_VER=$VERSION
-export DEBIAN_FRONTEND="noninteractive"
-apt update
-apt install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    unzip \
-    xz-utils \
-    zip \
-    file
+check_packages wget gpg
 
-case "$(dpkg --print-architecture)" in
-amd64)
-    DART_SHA256=cccd5300faa5a9abce12a5f77586e26350028cea82bb4ff8eeb55641b58a2e1d
-    SDK_ARCH="x64"
-    ;;
-armhf)
-    DART_SHA256=3a15d42cb1677ac5e50a23045cafe3bf5db2855a5287a3e9019b849fe8477897
-    SDK_ARCH="arm"
-    ;;
-arm64)
-    DART_SHA256=2c8eeaf0d3da60c4e14beec45ce3b39aca754f71b9fa3fb0c635ee28d6f44708
-    SDK_ARCH="arm64"
-    ;;
-esac
-
-SDK="dartsdk-linux-${SDK_ARCH}-release.zip"
-URL="$BASEURL/stable/release/${DART_VER}/sdk/$SDK"
-curl -fLO "$URL"
-echo "$DART_SHA256 *$SDK" | sha256sum --check --status --strict -
-unzip "$SDK"
-mv dart-sdk "$DART_ROOT"
-rm "$SDK"
-chmod 755 "$DART_ROOT"
-chmod 755 "$DART_ROOT/bin"
+sudo apt-get update
+sudo apt-get install apt-transport-https
+wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list

--- a/lib.sh
+++ b/lib.sh
@@ -15,3 +15,15 @@ check_packages() {
         apt-get -y install --no-install-recommends "$@"
     fi
 }
+
+updaterc() {
+    # if [ "${UPDATE_RC}" = "true" ]; then
+        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+        if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
+            echo -e "$1" >> /etc/bash.bashrc
+        fi
+        if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
+            echo -e "$1" >> /etc/zsh/zshrc
+        fi
+    # fi
+}

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+apt_get_update()
+{
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}


### PR DESCRIPTION
https://dart.dev/get-dart

![image](https://github.com/devcontainers-community/features-dart-sdk/assets/61068799/49a6582c-1e81-4a7a-9117-811f03366182)

![image](https://github.com/devcontainers-community/features-dart-sdk/assets/61068799/84e2ceec-435e-4f11-9d83-70a5f1d6a05a)

i _think_ this supports ARM too? that's important for macOS folks using M1 macs who user devcontainers locally