### PR TITLE
Work around devcontainers-community/publish-feature#4

### DIFF
--- a/.github/workflows/publish-feature.yml
+++ b/.github/workflows/publish-feature.yml
@@ -20,3 +20,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: devcontainers-community/publish-feature@v1
+        with:
+          files: |
+            install.sh
+            README.md
+            devcontainer-feature.json
+            LICENSE
+            test.sh


### PR DESCRIPTION
This works around a bug where tar files could be generated with two different instances of the same file, which in turn tickles a crashing bug in the container builder (https://github.com/devcontainers/cli/issues/699). This is the same solution as in devcontainers-community/features-llvm#7 and devcontainers-community/features-bazel#13.

Closes #3

<!-- Thanks for contributing! ❤️ -->
